### PR TITLE
Fix tests

### DIFF
--- a/dilicom_api.gemspec
+++ b/dilicom_api.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'tzinfo'
 
   gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'faraday_simulation'
   gem.add_development_dependency 'gem-release'
 
   gem.required_ruby_version = '>= 2.0.0'

--- a/spec/hub/api/get_notices_spec.rb
+++ b/spec/hub/api/get_notices_spec.rb
@@ -35,7 +35,7 @@ describe DilicomApi::Hub::Client do
         end
       end
       links = subject.send(method, *method_parameters)
-      expect(called).to be_true
+      expect(called).to be true
     end
     it "should return array of links" do
       set_connection do |stub|

--- a/spec/hub/client_spec.rb
+++ b/spec/hub/client_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'json'
 describe DilicomApi::Hub::Client do
-  
   include_context "faraday connection"
 
   describe "#json_request" do
@@ -17,7 +16,7 @@ describe DilicomApi::Hub::Client do
         subject.password = password
         headers = {}
         set_connection do |stub|
-          stub.get(example_end_point) do |env|   
+          stub.get(example_end_point) do |env|
             headers = env[:request_headers]
             [200, {}, "{}"]
           end
@@ -28,7 +27,7 @@ describe DilicomApi::Hub::Client do
       it "should send a json header" do
         headers = {}
         set_connection do |stub|
-          stub.get(example_end_point) do |env|   
+          stub.get(example_end_point) do |env|
             headers = env[:request_headers]
             [200, {}, "{}"]
           end
@@ -39,7 +38,7 @@ describe DilicomApi::Hub::Client do
       it "should send URI parameters" do
         received = {}
         set_connection do |stub|
-          stub.get(example_end_point) do |env|   
+          stub.get(example_end_point) do |env|
             received = env[:params]
             [200, {}, "{}"]
           end
@@ -51,7 +50,7 @@ describe DilicomApi::Hub::Client do
     context "when get an HTTP error" do
       it "should raise an exception" do
         set_connection do |stub|
-          stub.get(example_end_point) do |env|   
+          stub.get(example_end_point) do |env|
             received = env[:params]
             [400, {}, "{}"]
           end
@@ -62,7 +61,7 @@ describe DilicomApi::Hub::Client do
     context "when get a non-json response" do
       it "should raise an exception" do
         set_connection do |stub|
-          stub.get(example_end_point) do |env|   
+          stub.get(example_end_point) do |env|
             received = env[:params]
             [200, {}, "non json"]
           end
@@ -73,7 +72,7 @@ describe DilicomApi::Hub::Client do
     context "when get a dilicom return status error" do
       it "should raise an exception" do
         set_connection do |stub|
-          stub.get(example_end_point) do |env|   
+          stub.get(example_end_point) do |env|
             received = env[:params]
             [200, {}, "{\"returnStatus\":\"ERROR\"}"]
           end
@@ -84,7 +83,7 @@ describe DilicomApi::Hub::Client do
     context "when get a successfull response" do
       it "should answer json" do
         set_connection do |stub|
-          stub.get(example_end_point) do |env|   
+          stub.get(example_end_point) do |env|
             received = env[:params]
             [200, {}, JSON.dump(params)]
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,5 @@ Dir[File.join(File.dirname(__FILE__),"support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   # some (optional) config here
-  config.color_enabled = true
   config.formatter     = 'documentation'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,10 @@
 require 'rubygems'
 require 'bundler/setup'
 require 'rspec'
-require 'dilicom_api' 
+require 'dilicom_api'
 require 'faraday_simulation'
 require 'active_support/all'
 require 'json'
-
-
 
 Dir[File.join(File.dirname(__FILE__),"support/**/*.rb")].each { |f| require f }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require 'bundler/setup'
 require 'rspec'
 require 'dilicom_api'
-require 'faraday_simulation'
 require 'active_support/all'
 require 'json'
 

--- a/spec/support/faraday_connection_context.rb
+++ b/spec/support/faraday_connection_context.rb
@@ -5,7 +5,7 @@ shared_context "faraday connection" do
   def set_connection(&block)
     subject.connection = Faraday.new do |builder|
       subject.send(:faraday_builder, builder)
-      builder.use(FaradaySimulation::Adapter) do |stub|
+      builder.adapter :test do |stub|
         block.call(stub) if block
       end
     end


### PR DESCRIPTION
With this list of gems, all tests failed:
```
$ bundle list
Gems included by the bundle:
  * activesupport (4.2.0)
  * bundler (1.7.9)
  * diff-lcs (1.2.5)
  * dilicom_api (0.0.5)
  * faraday (0.9.0)
  * faraday_middleware (0.9.1)
  * faraday_simulation (0.0.2)
  * gem-release (0.7.3)
  * i18n (0.7.0)
  * json (1.8.1)
  * minitest (5.5.0)
  * multipart-post (2.0.0)
  * rake (10.4.2)
  * rspec (3.1.0)
  * rspec-core (3.1.7)
  * rspec-expectations (3.1.2)
  * rspec-mocks (3.1.3)
  * rspec-support (3.1.2)
  * thread_safe (0.3.4)
  * tzinfo (1.2.2)
```

After:
![capture d ecran 2014-12-24 a 10 32 11](https://cloud.githubusercontent.com/assets/411619/5547353/89545972-8b58-11e4-912d-55c236dc7100.png)